### PR TITLE
update from upstream

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,9 @@
-target
-.github
-.git
-.vscode
-Dockerfile
+# Ignore all
+*
+
+# And explicitly include...
+!/.cargo
+!/build-scripts
+!/Cargo.lock
+!/Cargo.toml
+!/src

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,10 @@
+Rules:
+
+- Be strict
+- Show places where downstream effects occur, e.g. when `iter()` causes `clone()`, post the lines of code where the `clone()` occurs as well
+- Don't assume
+- Think about the language, e.g. if it's Rust we care about memory.
+    - Don't suggest `fn foo(s: &str) -> String { todo!() }` is better than `fn foo(s: impl Into<Cow<'_, str>>) -> Cow<'_, str> { todo!() }` because
+      'in most places we pass something by ref'. Most is not all. This is NOT a good recommendation.
+      If there is a single place where we pass it by value our code is better, as it avoids allocations, even at the cost of reading complexity.
+    - `fn foo<'i, I: Into<Cow<'i, str>>>(f: I) -> Cow<'i, str> { todo!() }` is not complex, it is the correct way to write it in Rust

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -404,7 +404,8 @@ jobs:
     steps:
       - *checkout
 
-      - *cache_dependencies
+      # nothing to cache here
+      # - *cache_dependencies
 
       - *set_up_mold
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,7 @@
 {
     "debug.internalConsoleOptions": "neverOpen",
-    "lldb.launch.terminal": "integrated",
     "lldb.launch.expressions": "simple",
+    "lldb.launch.terminal": "integrated",
     "prettier.configPath": "./prettier.config.mjs",
     "rust-analyzer.runnables.extraEnv": {
         "RUST_LOG": "DEBUG,hw_monitor_alignment=TRACE"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
 # Rust toolchain setup
-FROM --platform=${BUILDPLATFORM} rust:1.89.0-trixie@sha256:26318aeddc7e7335b55ab32f943ec2d400bcc024649f8dbdee569bfa85f0c11d AS rust-base
+FROM --platform=${BUILDPLATFORM} rust:1.89.0-trixie@sha256:3329e2de3e9ff2d58da56e95ef99a3180a4e76336a676f3fe2b88f0b0d6bcfbf AS rust-base
 
 ARG APPLICATION_NAME
-
-ENV DEBIAN_FRONTEND=noninteractive
+ARG DEBIAN_FRONTEND=noninteractive
 
 RUN rm -f /etc/apt/apt.conf.d/docker-clean \
     && echo 'Binary::apt::APT::Keep-Downloaded-Packages "true";' > /etc/apt/apt.conf.d/keep-cache
@@ -18,6 +17,24 @@ RUN --mount=type=cache,id=apt-cache,target=/var/cache/apt,sharing=locked \
         build-essential \
         musl-dev
 
+FROM rust-base AS rust-linux-amd64
+ARG TARGET=x86_64-unknown-linux-musl
+
+FROM rust-base AS rust-linux-arm64
+ARG TARGET=aarch64-unknown-linux-musl
+
+FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+COPY ./build-scripts /build-scripts
+
+RUN --mount=type=cache,id=apt-cache-${TARGET},from=rust-base,target=/var/cache/apt,sharing=locked \
+    --mount=type=cache,id=apt-lib-${TARGET},from=rust-base,target=/var/lib/apt,sharing=locked \
+    /build-scripts/setup-env.sh
+
+RUN rustup target add ${TARGET}
+
 # The following block
 # creates an empty app, and we copy in Cargo.toml and Cargo.lock as they represent our dependencies
 # This allows us to copy in the source in a different layer which in turn allows us to leverage Docker's layer caching
@@ -29,31 +46,21 @@ RUN cargo init --name ${APPLICATION_NAME}
 COPY ./.cargo ./Cargo.toml ./Cargo.lock ./
 
 # We use `fetch` to pre-download the files to the cache
+# Notice we do this in the target arch specific branch
+# We do this because we want to do it after `setup-env.sh`,
+# as the env is less likely to change than the code
+# We do lock the cache, to avoid corruption when building it for
+# both target platforms. It doesn't matter, as after unlocking the other one
+# just validates, but doesn't need to download anything
 RUN --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db,sharing=locked \
-    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry,sharing=locked \
+    --mount=type=cache,id=cargo-registry-index,target=/usr/local/cargo/registry/index,sharing=locked \
+    --mount=type=cache,id=cargo-registry-cache,target=/usr/local/cargo/registry/cache,sharing=locked \
     cargo fetch
-
-FROM rust-base AS rust-linux-amd64
-ARG TARGET=x86_64-unknown-linux-musl
-
-FROM rust-base AS rust-linux-arm64
-ARG TARGET=aarch64-unknown-linux-musl
-
-FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
-
-ENV DEBIAN_FRONTEND=noninteractive
-
-COPY ./build-scripts /build-scripts
-
-RUN --mount=type=cache,id=apt-cache-${TARGET},from=rust-base,target=/var/cache/apt,sharing=locked \
-    --mount=type=cache,id=apt-lib-${TARGET},from=rust-base,target=/var/lib/apt,sharing=locked \
-    /build-scripts/setup-env.sh
-
-RUN rustup target add ${TARGET}
 
 RUN --mount=type=cache,target=/build/target/${TARGET},sharing=locked \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
-    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-registry-index,target=/usr/local/cargo/registry/index \
+    --mount=type=cache,id=cargo-registry-cache,target=/usr/local/cargo/registry/cache \
     /build-scripts/build.sh build --release --target ${TARGET} --target-dir ./target/${TARGET}
 
 # Rust full build
@@ -70,7 +77,8 @@ RUN touch ./src/main.rs
 # --release not needed, it is implied with install
 RUN --mount=type=cache,target=/build/target/${TARGET},sharing=locked \
     --mount=type=cache,id=cargo-git,target=/usr/local/cargo/git/db \
-    --mount=type=cache,id=cargo-registry,target=/usr/local/cargo/registry \
+    --mount=type=cache,id=cargo-registry-index,target=/usr/local/cargo/registry/index \
+    --mount=type=cache,id=cargo-registry-cache,target=/usr/local/cargo/registry/cache \
     /build-scripts/build.sh install --path . --locked --target ${TARGET} --target-dir ./target/${TARGET} --root /output
 
 # Container user setup


### PR DESCRIPTION
- **chore: sort**
- **fix: copilot instructions**
- **fix: fetch per arch, locked, and explicit import**
- **fix: src in registry should not be cached**
- **fix: lock fetch**
- **fix: bring ARG together**
- **chore: typo**
- **chore(deps): update rust:1.89.0-trixie docker digest to 3329e2d**
- **fix: disable cache dependencies for docker build, the downloading of ./target takes up too much space, and we're not building anyway**
