### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,13 +21,35 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
   CARGO_FEATURES: --all-features
-  # Use docker.io for Docker Hub if empty
-  REGISTRY: ghcr.io
   # github.repository as <account>/<repo>
   IMAGE_NAME: ${{ github.repository }}
+  IMAGE_VARIANTS: |-
+    arm64
+    amd64
+    amd64/v2
+    amd64/v3
+  # Use docker.io for Docker Hub if empty
+  REGISTRY: ghcr.io
   RUSTFLAGS: --deny=warnings
 
 jobs:
+  architectures:
+    name: Build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      architectures: ${{ steps.matrix.outputs.architectures }}
+    steps:
+      - name: Build matrix
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        id: matrix
+        with:
+          script: |
+            const architectures = process.env.IMAGE_VARIANTS.trim().split("\n").map((a) => a.trim());
+
+            const json = JSON.stringify(architectures);
+
+            core.setOutput("architectures", json);
+
   repo-has-container:
     name: Repo has container?
     runs-on: ubuntu-latest
@@ -84,6 +106,7 @@ jobs:
           show-progress: false
           fetch-depth: 0
 
+      # when updating this, ensure you update the `Cache cargo` step in the `docker-build` job
       - &cache_cargo
         name: Cache cargo
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
@@ -385,14 +408,39 @@ jobs:
         with:
           args: ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace --verbose
 
-  # this name is also used in `publish-crate-after-release.yml`
-  docker-build:
-    name: Build Docker container on ${{ matrix.runs-on }}
+  prebuild-cargo-edit-cargo-get:
+    name: Prebuild cargo-edit and cargo-get for ${{ matrix.runs-on }}
     strategy:
       matrix:
         runs-on:
           - "ubuntu-latest"
           - "ubuntu-24.04-arm"
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+      - *checkout
+
+      - *cache_cargo
+
+      - *set_up_mold
+
+      - *set_up_toolchain
+
+      - *get_binstall
+
+      - name: Install cargo-edit to do set-version, and cargo-get to get the description
+        shell: bash
+        run: |
+          cargo binstall --github-token ${{ secrets.GITHUB_TOKEN }} --no-confirm cargo-edit cargo-get
+
+  # this name is also used in `publish-crate-after-release.yml`
+  docker-build:
+    name: Build Docker container on ${{ matrix.runs-on }} for ${{ matrix.platform }}
+    strategy:
+      matrix:
+        runs-on:
+          - "ubuntu-latest"
+          - "ubuntu-24.04-arm"
+        platform: ${{ fromJSON(needs.architectures.outputs.architectures) }}
     outputs:
       application_name: ${{ steps.variables.outputs.application_name }}
       description: ${{ steps.variables.outputs.description }}
@@ -406,12 +454,33 @@ jobs:
       packages: write
     needs:
       - calculate-version
+      - architectures
+      # ensures cache of cargo-edit and cargo-get
+      - prebuild-cargo-edit-cargo-get
     # if:
     # ... is not needed because calculate-version will not run if we disable building the docker container
     steps:
       - *checkout
 
-      - *cache_cargo
+      - name: Cache cargo
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        env:
+          CACHE_NAME: cargo
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.job }}
+          # deviation from standard `*cache_cargo`, we want the cache from `prebuild-cargo-edit-cargo-get`
+          # as that one prebuilds it for us
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-prebuild-cargo-edit-cargo-get
+            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
+            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-
 
       - *set_up_mold
 
@@ -444,6 +513,15 @@ jobs:
           # This is the unique docker tag
           unique_tag=pr-${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
           echo "unique_tag=${unique_tag}" >> ${GITHUB_OUTPUT}
+
+          # remove slashes from platform (`amd64/v3` -> `amd64-v3`)
+          platform_no_slashes=${{ matrix.platform }}
+          platform_no_slashes=${platform_no_slashes//\//-}
+          echo "platform_no_slashes=${platform_no_slashes}" >> ${GITHUB_OUTPUT}
+
+          # but we're only building 1 arch here, so we need to identify that container (we'll merge them later)
+          unique_tag_arch=${unique_tag}-${platform_no_slashes}
+          echo "unique_tag_arch=${unique_tag_arch}" >> ${GITHUB_OUTPUT}
 
           # The application name, used in the Dockerfile
           application_name=${{ env.IMAGE_NAME }}
@@ -479,13 +557,13 @@ jobs:
         id: meta
         with:
           labels: |
-            org.opencontainers.image.description=${{ steps.variables.outputs.description }}
+            org.opencontainers.image.description=${{ steps.variables.outputs.description }} (${{ matrix.platform }})
             org.opencontainers.image.revision=${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
             org.opencontainers.image.source=${{ github.event.pull_request.html_url }}
             org.opencontainers.image.version=pr-${{ github.event.number }}
           images: ${{ steps.variables.outputs.full_image_name_local_registry }}
           tags: |
-            type=raw,value=${{ steps.variables.outputs.unique_tag }}
+            type=raw,value=${{ steps.variables.outputs.unique_tag_arch }}
 
       - name: Log into registry ${{ steps.variables.outputs.registry }}
         uses: docker/login-action@184bdaa0721073962dff0199f1fb9940f07167d1 # v3.5.0
@@ -494,8 +572,23 @@ jobs:
           registry: ${{ steps.variables.outputs.registry }}
           username: ${{ github.actor }}
 
+      - name: Should we set up QEMU?
+        shell: bash
+        id: setup_qemu
+        run: |
+          base_platform="${{ matrix.platform }}"
+
+          if ! dpkg-architecture --equal "${base_platform%/*}"; then
+            echo "setup_qemu=true" >> ${GITHUB_OUTPUT}
+          else
+            echo "setup_qemu=false" >> ${GITHUB_OUTPUT}
+          fi
+
       - name: Set up QEMU
         uses: docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392 # v3.6.0
+        if: fromJSON(steps.setup_qemu.outputs.setup_qemu) == true
+        with:
+          platforms: linux/${{ matrix.platform }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
@@ -508,11 +601,11 @@ jobs:
           context: .
           # this container is THE PR's artifact, and we will re-tag it
           # once the PR has been accepted
-          cache-from: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}-cache:${{ steps.variables.outputs.application_name }}-buildcache-${{ runner.arch }}
-          cache-to: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}-cache:${{ steps.variables.outputs.application_name }}-buildcache-${{ runner.arch }},mode=max
+          cache-from: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}-cache:${{ steps.variables.outputs.application_name }}-buildcache-${{ runner.arch }}-${{ steps.variables.outputs.platform_no_slashes }}
+          cache-to: type=registry,ref=${{ steps.variables.outputs.full_image_name_remote_registry }}-cache:${{ steps.variables.outputs.application_name }}-buildcache-${{ runner.arch }}-${{ steps.variables.outputs.platform_no_slashes }},mode=max
           labels: ${{ steps.meta.outputs.labels }}
-          outputs: type=oci,dest=/tmp/${{ steps.variables.outputs.unique_tag }}.tar
-          platforms: linux/amd64,linux/arm64
+          outputs: type=oci,dest=/tmp/${{ steps.variables.outputs.unique_tag_arch }}.tar
+          platforms: linux/${{ matrix.platform }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Upload artifact
@@ -521,8 +614,8 @@ jobs:
           matrix.runs-on == 'ubuntu-latest'
         with:
           if-no-files-found: error
-          name: container-${{ steps.variables.outputs.application_name }}
-          path: /tmp/${{ steps.variables.outputs.unique_tag }}.tar
+          name: container-${{ steps.variables.outputs.application_name }}-${{ steps.variables.outputs.platform_no_slashes }}
+          path: /tmp/${{ steps.variables.outputs.unique_tag_arch }}.tar
           retention-days: 1
 
   docker-publish:
@@ -570,6 +663,11 @@ jobs:
         id: meta
         with:
           images: ${{ needs.docker-build.outputs.full_image_name_remote_registry }}
+          labels: |
+            org.opencontainers.image.description=${{ needs.docker-build.outputs.description }}
+            org.opencontainers.image.revision=${{ github.event.pull_request.base.sha }}-${{ github.event.pull_request.head.sha }}
+            org.opencontainers.image.source=${{ github.event.pull_request.html_url }}
+            org.opencontainers.image.version=pr-${{ github.event.number }}
           tags: |
             type=raw,value=${{ needs.docker-build.outputs.unique_tag }}
             type=ref,event=pr,suffix=-latest
@@ -578,15 +676,40 @@ jobs:
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         id: artifact
         with:
+          merge-multiple: true
           path: /tmp/container/
-          name: container-${{ needs.docker-build.outputs.application_name }}
+          pattern: container-${{ needs.docker-build.outputs.application_name }}-*
 
-      - name: Load image from artifacts & push to registry
+      - name: Load individual platform images from artifacts & push to registry
         shell: bash
         working-directory: ${{ steps.artifact.outputs.download-path }}
         run: |
-          docker load --input ./${{ needs.docker-build.outputs.unique_tag }}.tar
-          docker push ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}
+          platforms=()
+          while IFS= read -r platform; do
+            echo "Loading ${platform//\//-}:"
+            docker load --input ./${{ needs.docker-build.outputs.unique_tag }}-${platform//\//-}.tar
+
+            full_name_with_platform=${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}-${platform//\//-}
+
+            echo "Pushing ${platform//\//-}:"
+            docker push $full_name_with_platform
+
+            platforms+=("$full_name_with_platform")
+          done <<< "${{ env.IMAGE_VARIANTS }}"
+
+          new_labels=()
+          while IFS= read -r label; do
+            new_labels+=(--annotation)
+            new_labels+=("index:${label}")
+          done <<< "${{ steps.meta.outputs.labels }}"
+
+          # merge the platform containers in a new multiplatform one
+          # with the new labels, and push it to our local registry
+          docker buildx imagetools create "${new_labels[@]}" --tag "${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}" \
+            "${platforms[@]}"
+
+          echo "Inspecting ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}:"
+          docker buildx imagetools inspect --raw ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}
 
       - name: Get digest of image in our local registry
         shell: bash
@@ -596,7 +719,7 @@ jobs:
 
           echo "digest=${digest}" >> ${GITHUB_OUTPUT}
 
-      - name: Set new tags
+      - name: Push from local registry to remote with new tags
         shell: bash
         run: |
           new_tags=()
@@ -605,8 +728,7 @@ jobs:
             new_tags+=(${tag})
           done <<< "${{ steps.meta.outputs.tags }}"
 
-          # merge labels & annotations
-          docker buildx imagetools create "${new_tags[@]}" "${new_labels[@]}" \
+          docker buildx imagetools create "${new_tags[@]}" \
             ${{ needs.docker-build.outputs.full_image_name_local_registry }}:${{ needs.docker-build.outputs.unique_tag }}
 
           for new_tag in $(echo "${{ join(steps.meta.outputs.tags, ' ') }}"); do

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Rust toolchain setup
-FROM --platform=${BUILDPLATFORM} rust:1.90.0-trixie@sha256:eabb786e74b520e7ea45baca03ea20c3e8c6dc037c392d457badf05d8e5818b5 AS rust-base
+FROM --platform=${BUILDPLATFORM} rust:1.90.0-slim-trixie@sha256:40d4ee109c7e740b3a242f20cc3b5790af9c725828b86a458765f192391a6a4a AS rust-base
 
 ARG APPLICATION_NAME
 ARG DEBIAN_FRONTEND=noninteractive
@@ -23,9 +23,11 @@ ARG TARGET=x86_64-unknown-linux-musl
 FROM rust-base AS rust-linux-arm64
 ARG TARGET=aarch64-unknown-linux-musl
 
-FROM rust-${TARGETPLATFORM//\//-} AS rust-cargo-build
+FROM rust-linux-${TARGETARCH//\//-} AS rust-cargo-build
 
 ARG DEBIAN_FRONTEND=noninteractive
+# expose into `build.sh`
+ARG TARGETVARIANT
 
 COPY ./build-scripts /build-scripts
 
@@ -95,6 +97,8 @@ RUN cat /etc/passwd | grep appuser > /tmp/passwd_appuser
 FROM scratch
 
 ARG APPLICATION_NAME
+ARG TARGETARCH
+ARG TARGETVARIANT
 
 COPY --from=passwd-build /tmp/group_appuser /etc/group
 COPY --from=passwd-build /tmp/passwd_appuser /etc/passwd
@@ -104,6 +108,8 @@ COPY --from=rust-build /output/bin/${APPLICATION_NAME} /app/entrypoint
 USER appuser
 
 ENV RUST_BACKTRACE=full
+ENV TARGETARCH=${TARGETARCH}
+ENV TARGETVARIANT=${TARGETVARIANT}
 
 WORKDIR /app
 

--- a/build-all.sh
+++ b/build-all.sh
@@ -6,7 +6,7 @@ build() {
     PLATFORM=$2
     docker build \
         --file Dockerfile . \
-        --tag $APPLICATION_NAME:latest \
+        --tag $APPLICATION_NAME:latest-${2//\//-} \
         --build-arg APPLICATION_NAME=$APPLICATION_NAME \
         --platform $PLATFORM \
         --progress=plain
@@ -14,5 +14,7 @@ build() {
 
 name=$(basename ${PWD})
 
+build $name linux/amd64/v3
+build $name linux/amd64/v2
 build $name linux/amd64
 build $name linux/arm64

--- a/build-scripts/build.sh
+++ b/build-scripts/build.sh
@@ -3,13 +3,17 @@
 # sane defaults
 c_compiler="gcc"
 cpp_compiler="g++"
-
-rust_flags="-Clink-self-contained=yes -Clinker=rust-lld"
+target_cpu=""
 
 case $TARGET in
     x86_64-unknown-linux-musl)
         c_compiler="x86_64-linux-musl-gcc"
         cpp_compiler="x86_64-linux-musl-g++"
+
+        if ! [[ -z "${TARGETVARIANT}" ]]; then
+            target_cpu="-Ctarget-cpu=x86-64-${TARGETVARIANT}"
+        fi
+
         ;;
     aarch64-unknown-linux-musl)
         c_compiler="aarch64-linux-musl-gcc"
@@ -20,6 +24,8 @@ case $TARGET in
         exit 1
         ;;
 esac
+
+rust_flags="-Clink-self-contained=yes -Clinker=rust-lld ${target_cpu}"
 
 # replace - with _ in the Rust target
 target_lower=${TARGET//-/_}


### PR DESCRIPTION
- **chore(deps): update pnpm to v10.17.1**
- **chore(deps): update returntocorp/semgrep docker tag to v1.137.1**
- **chore(deps): update actions/cache action to v4.3.0**
- **chore(deps): update github/codeql-action action to v3.30.4**
- **chore(deps): update returntocorp/semgrep docker tag to v1.138.0**
- **chore(deps): update node.js to v24.9.0**
- **chore(deps): update github/codeql-action action to v3.30.5**
- **chore: use slim-trixie instead of trixie**
- **chore(deps): pin rust docker tag to 40d4ee1**
- **chore(ci): add step that builds cargo-edit and cargo-get before the docker build. Docker build will then pick up cached version**
- **chore(ci): add comment ensuring the non-standard action gets updated**
- **chore(ci): split builds again for speed**
- **chore(ci): reduce platforms for qemu**
- **feat(ci): multi level**
- **chore(deps): pin actions/github-script action to f28e40c**
- **chore(deps): update actions/github-script action to v7.1.0**
- **feat: use target cpu for optimal builds**
- **chore(ci): use github-scripts@v8**
- **chore(fmt): fmt**
- **chore(deps): pin actions/github-script action to ed59741**
