### PR TITLE
update from upstream

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,14 +408,17 @@ jobs:
         with:
           args: ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace --verbose
 
-  prebuild-cargo-edit-cargo-get:
-    name: Prebuild cargo-edit and cargo-get for ${{ matrix.runs-on }}
+  pre-build-cargo-edit-cargo-get:
+    name: pre-build cargo-edit and cargo-get for ${{ matrix.runs-on }}
     strategy:
       matrix:
         runs-on:
           - "ubuntu-latest"
           - "ubuntu-24.04-arm"
     runs-on: ${{ matrix.runs-on }}
+    needs:
+      - repo-has-container
+    if: fromJSON(needs.repo-has-container.outputs.has_container) == true
     steps:
       - *checkout
 
@@ -456,7 +459,7 @@ jobs:
       - calculate-version
       - architectures
       # ensures cache of cargo-edit and cargo-get
-      - prebuild-cargo-edit-cargo-get
+      - pre-build-cargo-edit-cargo-get
     # if:
     # ... is not needed because calculate-version will not run if we disable building the docker container
     steps:
@@ -475,10 +478,10 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.job }}
-          # deviation from standard `*cache_cargo`, we want the cache from `prebuild-cargo-edit-cargo-get`
-          # as that one prebuilds it for us
+          # deviation from standard `*cache_cargo`, we want the cache from `pre-build-cargo-edit-cargo-get`
+          # as that one pre-builds it for us
           restore-keys: |
-            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-prebuild-cargo-edit-cargo-get
+            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-pre-build-cargo-edit-cargo-get
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-
 


### PR DESCRIPTION
- **chore(deps): update docker/login-action action to v3.6.0**
- **chore(deps): update rust:1.90.0-slim-trixie docker digest to 5569ca9**
- **chore(deps): update rust:1.90.0-slim-trixie docker digest to ba1dce9**
- **chore(deps): update returntocorp/semgrep docker tag to v1.139.0**
- **chore(deps): update rust:1.90.0-slim-trixie docker digest to 33b421a**
- **chore(deps): update github/codeql-action action to v3.30.6**
- **chore(deps): update pnpm to v10.18.0**
- **chore(deps): update rust:1.90.0-slim-trixie docker digest to e4ae8ab**
- **fix(ci): only pre-build cargo-edit when we actually build a container**
- **chore: prebuild -> pre-build**
- **chore: fmt**
