### PR TITLE
chore: pin cache for warmup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,34 +20,8 @@ permissions:
 
 env:
   CARGO_TERM_COLOR: always
-  # github.repository as <account>/<repo>
-  IMAGE_NAME: ${{ github.repository }}
-  IMAGE_VARIANTS: |-
-    arm64
-    amd64
-    amd64/v2
-    amd64/v3
-  REGISTRY: ghcr.io
 
 jobs:
-  architectures:
-    name: Build matrix
-    runs-on: ubuntu-slim
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
-    outputs:
-      architectures: ${{ steps.matrix.outputs.architectures }}
-    steps:
-      - name: Build matrix
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        id: matrix
-        with:
-          script: |
-            const architectures = process.env.IMAGE_VARIANTS.trim().split("\n").map((a) => a.trim());
-
-            const json = JSON.stringify(architectures);
-
-            core.setOutput("architectures", json);
-
   rust-build:
     name: Build Rust code
     if: ${{ !startsWith(github.head_ref, 'release/') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,20 +59,6 @@ jobs:
       id-token: write
       pull-requests: write
 
-  repo-has-container:
-    name: Repo has container?
-    runs-on: ubuntu-slim
-    if: ${{ !startsWith(github.head_ref, 'release/') }}
-    outputs:
-      has_container: ${{ steps.determine.outputs.has_container }}
-    steps:
-      - name: Repo has docker container?
-        shell: bash
-        id: determine
-        run: |
-          has_container="${{ vars.HAS_CONTAINER }}"
-          echo "has_container=${has_container:-false}" >> "${GITHUB_OUTPUT}"
-
   changes:
     name: Detect changes
     runs-on: ubuntu-slim
@@ -104,12 +90,10 @@ jobs:
       contents: read
     needs:
       - changes
-      - repo-has-container
     outputs:
       version: ${{ steps.version.outputs.version }}
     if: |
       github.event_name == 'pull_request' &&
-      fromJSON(needs.repo-has-container.outputs.has_container) == true &&
       (
         fromJSON(needs.changes.outputs.docker) == true ||
         fromJSON(needs.changes.outputs.rust) == true

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -30,8 +30,7 @@ jobs:
         with:
           show-progress: false
 
-      - &cache_cargo_windows
-        name: Cache cargo
+      - name: Cache cargo
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         env:
           CACHE_NAME: cargo
@@ -43,7 +42,7 @@ jobs:
             ~/.cargo/registry/index/
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
-          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.workflow }}-${{ github.job }}
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.workflow }}-warm-up-cache
           restore-keys: |
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.workflow }}-
             ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-
@@ -72,6 +71,7 @@ jobs:
         shell: pwsh
         run: |
           cargo fetch --locked
+
   changes:
     name: Detect changes
     runs-on: ubuntu-slim
@@ -100,7 +100,22 @@ jobs:
 
       - *checkout
 
-      - *cache_cargo_windows
+      - &cache_cargo_windows
+        name: Cache cargo
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        env:
+          CACHE_NAME: cargo
+        with:
+          path: |
+            ~/.cargo/.crates.toml
+            ~/.cargo/.crates2.json
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+          key: ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.workflow }}-warm-up-cache
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-build-${{ env.CACHE_NAME }}-${{ hashFiles('Cargo.lock') }}-${{ github.workflow }}-
 
       - *set_up_mold
 
@@ -289,7 +304,7 @@ jobs:
       - name: Run Clippy for GitHub Actions report
         uses: actions-rs-plus/clippy-check@23b52efac3da0e2b197a9ad2e7be0f515502aaaf # v2.5.0
         with:
-          args: --all-features --all-targets --locked --workspace --verbose
+          args: ${{ env.CARGO_FEATURES }} --all-targets --locked --workspace
 
   all-done:
     name: Rust All done

--- a/README.md
+++ b/README.md
@@ -1,23 +1,4 @@
-# Rust seed application
-
-This is a framework for building Rust applications
-
-It supports:
-
-- Building multi-platform images
-- Reusing images when merging in PRs to preserve provenance
-    - Support for tags like `pr-${PR_NUMBER}-latest` (last build on PR), `edge` (last build on `main`), `pr-${SHA_MAIN_HEAD}-${SHA_PR_HEAD}` (uniquely identifying the merge result of a PR)
-- Container attestation
-- Crate publishing
-- Release publishing
-    - Crate publishing to crates.io
-    - Container re-tagging to `:latest`
-
-## TODO
-
-- [ ] Remove old containers when the new one gets build for a PR?<br />
-      Or rely on a general weekly untagged cleanup?
-- [ ] Remove PR containers when PR closed<br />
+# HwMonitorAlignment
 
 ## License
 

--- a/crates/hw-monitor-alignment/README.md
+++ b/crates/hw-monitor-alignment/README.md
@@ -1,1 +1,1 @@
-# HwMonitorAlignment
+# HwMonitorAlignment main crate


### PR DESCRIPTION
We want warm-up-cache to only reuse its own, because for some reason, GitHub Actions doesn't save the cache when it found a match, even if it's not a precise match.